### PR TITLE
1. update Readme for alternative config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,9 @@ To display what page you're on, I'd highly recommend checking out my
 ## Using the module
 
 To use this module, add it to the modules array in the `config/config.js` file.
-Note: module names used in the following example are fictitious.
+Note: module names used in the following example are fictitious. this approach uses the module names as the page organization technique, as the modulename is added as a css class in the MM page content. 
+Because  the modulename is used, this approach does not support multiple instances of the same module with data 
+on different pages. (like your calendar on page 1, and someone elses on page 2)
 
 ```js
 modules: [
@@ -75,6 +77,58 @@ modules: [
         }
     }
 ]
+```
+
+and alternative approach, is to define a fixed MMM-Pages config
+
+```js
+modules: [
+    {
+        module: 'MMM-pages',
+        config: {
+                modules:
+                    [[ "page1" ],
+                     [ "page2" ]],
+                fixed: [ "fixed_page" ],
+                hiddenPages: {
+                    "screenSaver": [ "screensaver_page" ],
+                    "admin": [ "admin_page" ],
+                },
+        }
+    }
+]
+```
+and then at each module, add a classes: property to indicate the page(s) this is supposed to appear on
+```
+  { 
+    module:"newsfeed",
+    classes:"page1",
+  },
+  {
+    module:"calendar",
+    classes:"page2",
+  },
+  {
+    module:"compliments",
+    classes:"page2",
+  }
+```
+etc
+
+if u want a modules content on multiple pages the classes has those page names
+```
+  { 
+    module:"newsfeed",
+    classes:"page1",
+  },
+  {
+    module:"calendar",
+    classes:"page2",
+  },
+  {
+    module:"compliments",
+    classes:"page1, page2",
+  }
 ```
 
 ## Configuration options

--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ if u want a modules content on multiple pages the classes has those page names
   },  
   {
     module:"compliments",
-    classes:"page1, page2",
+    classes:"page1 page2",
   }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,9 @@ modules: [
         config: {
                 modules:
                     [[ "page1" ],
-                     [ "page2" ]],
+                     [ "page2" ],
+                     [ "page3" ],
+                    ],
                 fixed: [ "fixed_page" ],
                 hiddenPages: {
                     "screenSaver": [ "screensaver_page" ],
@@ -122,9 +124,13 @@ if u want a modules content on multiple pages the classes has those page names
     classes:"page1",
   },
   {
-    module:"calendar",
+    module:"calendar",  // first calendar instance on page 2
     classes:"page2",
   },
+  {
+    module:"calendar",  // second calendar instance on page 3
+    classes:"page3",
+  },  
   {
     module:"compliments",
     classes:"page1, page2",

--- a/readme.md
+++ b/readme.md
@@ -57,8 +57,10 @@ To display what page you're on, I'd highly recommend checking out my
 ## Using the module
 
 To use this module, add it to the modules array in the `config/config.js` file.
-Note: module names used in the following example are fictitious. this approach uses the module names as the page organization technique, as the modulename is added as a css class in the MM page content. 
-Because  the modulename is used, this approach does not support multiple instances of the same module with data 
+Note: module names used in the following example are fictitious. 
+
+this approach uses the module names as the page organization technique, as the modulename is added as a css class in the MM page content. 
+Because the modulename is used, this approach does not support multiple instances of the same module with data 
 on different pages. (like your calendar on page 1, and someone elses on page 2)
 
 ```js
@@ -100,7 +102,7 @@ modules: [
     }
 ]
 ```
-and then at each module, add a classes: property to indicate the page(s) this is supposed to appear on
+and then at each module, add a classes: property to indicate the page(s) this module is supposed to appear on
 ```
   { 
     module:"newsfeed",
@@ -117,7 +119,7 @@ and then at each module, add a classes: property to indicate the page(s) this is
 ```
 etc
 
-if u want a modules content on multiple pages the classes has those page names
+if u want a modules content on multiple pages the classes would list those page names
 ```
   { 
     module:"newsfeed",
@@ -133,7 +135,7 @@ if u want a modules content on multiple pages the classes has those page names
   },  
   {
     module:"compliments",
-    classes:"page1 page2",
+    classes:"page1 page2",  // this module appears on multiple pages
   }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ modules: [
 ]
 ```
 
-and alternative approach, is to define a fixed MMM-Pages config
+an alternative approach, is to define a fixed MMM-Pages config
 
 ```js
 modules: [
@@ -89,9 +89,10 @@ modules: [
         module: 'MMM-pages',
         config: {
                 modules:
-                    [[ "page1" ],
+                    [
+                     [ "page1" ],
                      [ "page2" ],
-                     [ "page3" ],
+                     [ "page3" ]
                     ],
                 fixed: [ "fixed_page" ],
                 hiddenPages: {


### PR DESCRIPTION
update the readme to show a different approach

using a fixed pages design 
page1, page2
mom, dad. son, daugther

and then use the classes tag at each module to inidcate the page

I was constantly looking back at the pages config trying to figure out which group(s) I wanted this module shown in
now I don't.
this is sons page
  school schedule, his sports schedule, 
this is Moms page
    family cal,  meal planner, shopping list, 
this is Dads page
   family cal,  meal planner, shopping list,  weather, soccer tracking..
this is daughter page
   school schedule, her sports schedule, 

the page names never change
