### PR TITLE
Optimize logging and fix typo

### DIFF
--- a/MMM-pages.js
+++ b/MMM-pages.js
@@ -54,12 +54,12 @@ Module.register('MMM-pages', {
 
     // Compatibility
     if (this.config.excludes.length) {
-      Log.warn('[Pages]: The config option "excludes" is deprecated. Please use "fixed" instead.');
+      Log.warn('[MMM-pages] The config option "excludes" is deprecated. Please use "fixed" instead.');
       this.config.fixed = this.config.excludes;
     }
 
     if (this.config.rotationFirstPage) {
-      Log.warn('[Pages]: The config option "rotationFirstPage" is deprecated. Please used "rotationHomePage" instead.');
+      Log.warn('[MMM-pages] The config option "rotationFirstPage" is deprecated. Please used "rotationHomePage" instead.');
       this.config.rotationHomePage = this.config.rotationFirstPage;
     }
 
@@ -69,7 +69,7 @@ Module.register('MMM-pages', {
     this.config.rotationHomePage = Math.max(this.config.rotationHomePage, 0);
 
     if (!this.config.useLockString) {
-      Log.log('[Pages]: User opted to not use lock strings!');
+      Log.info('[MMM-pages] User opted to not use lock strings!');
     }
   },
 
@@ -94,26 +94,24 @@ Module.register('MMM-pages', {
   notificationReceived: function (notification, payload) {
     switch (notification) {
       case 'PAGE_CHANGED':
-        Log.log('[Pages]: received a notification '
-          + `to change to page ${payload} of type ${typeof payload}`);
+        Log.log(`[MMM-pages] received a notification to change to page ${payload} of type ${typeof payload}.`);
         this.curPage = payload;
         this.updatePages();
         break;
       case 'PAGE_INCREMENT':
-        Log.log('[Pages]: received a notification to increment pages!');
+        Log.log('[MMM-pages] received a notification to increment pages!');
         this.changePageBy(payload, 1);
         this.updatePages();
         break;
       case 'PAGE_DECREMENT':
-        Log.log('[Pages]: received a notification to decrement pages!');
+        Log.log('[MMM-pages] received a notification to decrement pages!');
         // We can't just pass in -payload for situations where payload is null
         // JS will coerce -payload to -0.
         this.changePageBy(payload ? -payload : payload, -1);
         this.updatePages();
         break;
       case 'DOM_OBJECTS_CREATED':
-        Log.log('[Pages]: received that all objects are created;'
-          + ' will now hide things!');
+        Log.log('[MMM-pages] received that all objects are created; will now hide things!');
         this.sendNotification('MAX_PAGES_CHANGED', this.config.modules.length);
         this.sendNotification('NEW_PAGE', this.curPage);
         this.animatePageChange();
@@ -132,12 +130,12 @@ Module.register('MMM-pages', {
         this.notificationReceived('PAGE_CHANGED', this.config.homePage);
         break;
       case 'SHOW_HIDDEN_PAGE':
-        Log.log(`[Pages]: received a notification to change to the hidden page "${payload}" of type "${typeof payload}"`);
+        Log.log(`[MMM-pages] received a notification to change to the hidden page "${payload}" of type "${typeof payload}".`);
         this.setRotation(false);
         this.showHiddenPage(payload);
         break;
       case 'LEAVE_HIDDEN_PAGE':
-        Log.log("[Pages]: received a notification to leave the current hidden page ");
+        Log.log('[MMM-pages] received a notification to leave the current hidden page.');
         this.animatePageChange();
         this.setRotation(true);
         break;
@@ -157,7 +155,7 @@ Module.register('MMM-pages', {
    */
   changePageBy: function (amt, fallback) {
     if (typeof amt !== 'number' && typeof fallback === 'undefined') {
-      Log.warn(`[Pages]: ${amt} is not a number!`);
+      Log.warn(`[MMM-pages] ${amt} is not a number!`);
     }
 
     if (typeof amt === 'number' && !Number.isNaN(amt)) {
@@ -185,7 +183,7 @@ Module.register('MMM-pages', {
         this.resetTimerWithDelay(0);
       }
       this.sendNotification('NEW_PAGE', this.curPage);
-    } else { Log.error("[Pages]: Pages aren't properly defined!"); }
+    } else { Log.error('[MMM-pages] Pages aren\'t properly defined!'); }
   },
 
   /**
@@ -280,9 +278,9 @@ Module.register('MMM-pages', {
   setRotation: function (isRotating) {
     const stateBaseString = (isRotating) ? "resum" : "paus";
     if (isRotating === this.rotationPaused) {
-      Log.warn(`[Pages]: Was asked to ${stateBaseString}e but rotation is already ${stateBaseString}ed!`);
+      Log.warn(`[MMM-pages] was asked to ${stateBaseString}e but rotation is already ${stateBaseString}ed!`);
     } else {
-      Log.log(`[Pages]: ${stateBaseString}ing rotation`);
+      Log.log(`[MMM-pages] ${stateBaseString}ing rotation`);
       if (!isRotating) {
         clearInterval(this.timer);
         clearInterval(this.delayTimer);
@@ -303,7 +301,7 @@ Module.register('MMM-pages', {
     if (name in this.config.hiddenPages) {
       this.animatePageChange(name);
     } else {
-      Log.error(`Hidden page "${name}" does not exist!`);
+      Log.error(`[MMM-pages] Hidden page "${name}" does not exist!`);
     }
   },
 });

--- a/MMM-pages.js
+++ b/MMM-pages.js
@@ -69,7 +69,7 @@ Module.register('MMM-pages', {
     this.config.rotationHomePage = Math.max(this.config.rotationHomePage, 0);
 
     if (!this.config.useLockString) {
-      Log.info('[MMM-pages] User opted to not use lock strings!');
+      Log.log('[MMM-pages] User opted to not use lock strings!');
     }
   },
 

--- a/MMM-pages.js
+++ b/MMM-pages.js
@@ -176,7 +176,7 @@ Module.register('MMM-pages', {
    * elements.
    */
   updatePages: function () {
-    // Update iff there's at least one page.
+    // Update if there's at least one page.
     if (this.config.modules.length !== 0) {
       this.animatePageChange();
       if (!this.rotationPaused) {

--- a/MMM-pages.js
+++ b/MMM-pages.js
@@ -183,7 +183,7 @@ Module.register('MMM-pages', {
         this.resetTimerWithDelay(0);
       }
       this.sendNotification('NEW_PAGE', this.curPage);
-    } else { Log.error('[MMM-pages] Pages aren\'t properly defined!'); }
+    } else { Log.error('[MMM-pages] Pages are not properly defined!'); }
   },
 
   /**


### PR DESCRIPTION
The use of the full module name in the log prefix is now common practice for other modules.

In one log entry, the module prefix was even missing.

Fixing a typo is a bonus, I didn't want to do a extra PR for it :slightly_smiling_face: