### PR TITLE
Add missing package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mmm-pages",
+  "version": "1.0.0",
+  "description": "Add pages to your MagicMirror².",
+  "main": "MMM-pages.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/edward-shen/MMM-pages.git"
+  },
+  "keywords": [
+    "MagicMirror",
+    "pages",
+    "slides"
+  ],
+  "author": "Edward Shen",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/edward-shen/MMM-pages/issues"
+  },
+  "homepage": "https://github.com/edward-shen/MMM-pages#readme"
+}


### PR DESCRIPTION
We need this file for two reasons:

- [The new module list](https://kristjanesperanto.github.io/MagicMirror-3rd-Party-Modules/) needs this file to get keywords.
- In a next step I will take care of ESLint. ESLint and it's plugins should be in the `devDependencies` in the `package.json`.