### PR TITLE
Add callback to hide and show methods

### DIFF
--- a/MMM-pages.js
+++ b/MMM-pages.js
@@ -212,13 +212,13 @@ Module.register('MMM-pages', {
 
     MM.getModules()
       .exceptWithClass(modulesToShow)
-      .enumerate(module => module.hide(animationTime, lockStringObj));
+      .enumerate(module => module.hide(animationTime, () => {}, lockStringObj));
 
     // Shows all modules meant to be on the current page, after a small delay.
     setTimeout(() => {
       MM.getModules()
         .withClass(modulesToShow)
-        .enumerate(module => module.show(animationTime, lockStringObj));
+        .enumerate(module => module.show(animationTime, () => {}, lockStringObj));
     }, animationTime);
   },
 


### PR DESCRIPTION
The callback parameter is only optional, if you don't use the options. See MM documentation: <https://docs.magicmirror.builders/development/core-module-file.html#this-hide-speed-callback-option>.

Without this change you can see an error message in the browser console: {{callback is not an optional parameter!}}